### PR TITLE
Resolving compile time errors and warnings

### DIFF
--- a/Chapter-10/1_class_user.h
+++ b/Chapter-10/1_class_user.h
@@ -8,16 +8,16 @@ struct Address
   std::string country;
   std::string city;
   std::string street;
-  float latitude;
-  float longitude;
+  float latitude{};
+  float longitude{};
 };
 
 class User
 {
 public:
-    void User::set_email(const std::string& email)
+    void set_email(const std::string& email)
     {
-        if (!std::regex_match(email, "(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+") {
+        if (!std::regex_match(email, std::regex("(\\w+)(\\.|_)?(\\w*)@(\\w+)(\\.(\\w+))+"))) {
             throw std::invalid_argument("Invalid email");
         }
         


### PR DESCRIPTION
User::set_email. Qualified name is not allowed in member declaration.
fatal error C1075: '{': no matching token found (missing right parenthesis)
error C2672: 'std::regex_match': no matching overloaded function found
warning C26495: Variable 'Address::latitude' is uninitialized. Always initialize a member variable (type.6).